### PR TITLE
added pagination to the boss hiscores command.

### DIFF
--- a/tests/test_hiscores.py
+++ b/tests/test_hiscores.py
@@ -37,6 +37,7 @@ TEST_USERS_REGULAR = (
     'LazyKernel',
     'Santa Ends',
     'Sk8r Dan Man',
+    'bendzo'  # High EHB and boss kill count
 )
 TEST_USERS = (
     TEST_USERS_REGULAR


### PR DESCRIPTION
Integrates with current tests.
Uses a simple library called reactionmenu for the pagination.
Alternatively, this could have been just three printouts or three separate messages but the pagination is cooler IMHO?

Thought you might like this.

# Boss Hiscores Table pagination with buttons

## Description
When a player is looked up that has too many bosses listed on their hiscores page the current display which is with an ASCII table format exceeds discord's character limit of 2,000 in most cases.

Fixes Issue #22 

## Type of change

- [+] Bug fix (non-breaking change which fixes an issue)
- [+] New feature (non-breaking change which adds functionality) 

## How has this been tested?

- [x] test_hiscores 37/37


**Test Configuration**:

- python 3.10

